### PR TITLE
:zap: keyValue / middleware

### DIFF
--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -32,7 +32,16 @@ Object {
 
 exports[`index with middleware should prefix reducer 1`] = `
 Object {
-  "array": Array [],
+  "array": Array [
+    Object {
+      "id": 1,
+      "some": "information 1",
+    },
+    Object {
+      "id": 2,
+      "some": "information 2",
+    },
+  ],
   "data": Object {
     "1": Object {
       "id": 1,
@@ -47,8 +56,8 @@ Object {
   "initialized": true,
   "key": "id",
   "keys": Array [
-    1,
-    2,
+    "1",
+    "2",
   ],
   "name": "todos",
   "post1": true,
@@ -61,7 +70,16 @@ Object {
       "type": "@@krf/REMOVE>TODOS",
     },
     "state": Object {
-      "array": Array [],
+      "array": Array [
+        Object {
+          "id": 1,
+          "some": "information 1",
+        },
+        Object {
+          "id": 2,
+          "some": "information 2",
+        },
+      ],
       "data": Object {
         "1": Object {
           "id": 1,
@@ -76,8 +94,8 @@ Object {
       "initialized": true,
       "key": "id",
       "keys": Array [
-        1,
-        2,
+        "1",
+        "2",
       ],
       "name": "todos",
       "pre1": true,
@@ -104,9 +122,9 @@ Object {
           },
           "initialized": true,
           "keys": Array [
-            1,
-            20,
-            2,
+            "1",
+            "20",
+            "2",
           ],
         },
       },
@@ -144,7 +162,16 @@ Object {
 
 exports[`index with name and empty prefix should prefix reducer 1`] = `
 Object {
-  "array": Array [],
+  "array": Array [
+    Object {
+      "id": 1,
+      "some": "information 1",
+    },
+    Object {
+      "id": 2,
+      "some": "information 2",
+    },
+  ],
   "data": Object {
     "1": Object {
       "id": 1,
@@ -157,8 +184,8 @@ Object {
   },
   "initialized": true,
   "keys": Array [
-    1,
-    2,
+    "1",
+    "2",
   ],
 }
 `;
@@ -192,7 +219,16 @@ Object {
 
 exports[`index with name and prefix should prefix reducer 1`] = `
 Object {
-  "array": Array [],
+  "array": Array [
+    Object {
+      "id": 1,
+      "some": "information 1",
+    },
+    Object {
+      "id": 2,
+      "some": "information 2",
+    },
+  ],
   "data": Object {
     "1": Object {
       "id": 1,
@@ -205,8 +241,8 @@ Object {
   },
   "initialized": true,
   "keys": Array [
-    1,
-    2,
+    "1",
+    "2",
   ],
 }
 `;
@@ -240,7 +276,16 @@ Object {
 
 exports[`index with path should prefix reducer 1`] = `
 Object {
-  "array": Array [],
+  "array": Array [
+    Object {
+      "id": 1,
+      "some": "information 1",
+    },
+    Object {
+      "id": 2,
+      "some": "information 2",
+    },
+  ],
   "data": Object {
     "1": Object {
       "id": 1,
@@ -253,8 +298,8 @@ Object {
   },
   "initialized": true,
   "keys": Array [
-    1,
-    2,
+    "1",
+    "2",
   ],
 }
 `;
@@ -288,7 +333,16 @@ Object {
 
 exports[`index without path should prefix reducer 1`] = `
 Object {
-  "array": Array [],
+  "array": Array [
+    Object {
+      "id": 1,
+      "some": "information 1",
+    },
+    Object {
+      "id": 2,
+      "some": "information 2",
+    },
+  ],
   "data": Object {
     "1": Object {
       "id": 1,
@@ -301,8 +355,8 @@ Object {
   },
   "initialized": true,
   "keys": Array [
-    1,
-    2,
+    "1",
+    "2",
   ],
 }
 `;

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -9,7 +9,7 @@ const subState = {
     20: Todo(20),
     2: Todo(2),
   },
-  keys: [1, 20, 2],
+  keys: ['1', '20', '2'],
   initialized: true,
 }
 

--- a/src/types/keyValue/__snapshots__/keyValue.middleware.spec.js.snap
+++ b/src/types/keyValue/__snapshots__/keyValue.middleware.spec.js.snap
@@ -1064,7 +1064,7 @@ Object {
         },
       },
     },
-    "initialized": false,
+    "initialized": true,
     "keys": Array [
       "elm2",
       "elm3",
@@ -1103,7 +1103,7 @@ Object {
         },
       },
     },
-    "initialized": false,
+    "initialized": true,
     "keys": Array [
       "elm3",
     ],
@@ -1168,7 +1168,7 @@ Object {
         },
       },
     },
-    "initialized": false,
+    "initialized": true,
     "keys": Array [
       "elm2",
       "elm1",
@@ -1327,7 +1327,7 @@ Object {
         },
       },
     },
-    "initialized": false,
+    "initialized": true,
     "keys": Array [
       "elm2",
       "elm1",
@@ -1403,7 +1403,7 @@ Object {
         },
       },
     },
-    "initialized": false,
+    "initialized": true,
     "keys": Array [
       "elm2",
       "elm1",

--- a/src/types/keyValue/keyValue.middleware.js
+++ b/src/types/keyValue/keyValue.middleware.js
@@ -8,7 +8,16 @@ export const initState = {
   initialized: false,
 }
 
-const keyAlreadyExists = state => key => state.keys.includes(key)
+const getAsArray = entry => (Array.isArray(entry) ? entry : [entry])
+
+const toObject = (key, entry) => {
+  const object = {}
+  getAsArray(entry).forEach((entity) => { object[entity[key]] = entity })
+
+  return object
+}
+
+const keyAlreadyExists = state => key => (state.data[key] !== undefined)
 
 const mapDataToState = state => data => ({
   ...state,
@@ -18,14 +27,7 @@ const mapDataToState = state => data => ({
   initialized: true,
 })
 
-const set = (key, state, payload) => {
-  const data = [].concat(payload).reduce(
-    (acc, curr) => ({ ...acc, [curr[key]]: curr }),
-    {},
-  )
-
-  return mapDataToState(state)(data)
-}
+const set = (key, state, payload) => mapDataToState(state)(toObject(key, payload))
 
 const add = (key, state, payload) => {
   const instanceKey = payload[key]


### PR DESCRIPTION
 - remove some lodash functions. Bundle size!
 - factorize some code!
 - simplify construction of `array` and `keys`, from `data`object, avoiding a lot of processing

### next steps
 - remove all lodash functions
 - accept array as payload parameter for every keyValue actions (related to #105 )
    * By using the `[].concat(payload)` tip