### PR TITLE
:sparkles: keyValue / remove by object

### DIFF
--- a/TYPES.md
+++ b/TYPES.md
@@ -83,7 +83,7 @@ Parameters are :
 | `add` | add instance(s) of your resource | `add(<instance>)` or `add(<array>)` | `{ type: '@@krf/ADD>TODOS', payload: <instance> or <array> }` |
 | `update` | update existing instance(s) of your resource | `update(<instance>)` or `update(<array>)` | `{ type: '@@krf/UPDATE>TODOS', payload: <instance> or <array> }` |
 | `addOrUpdate` | update existing instance(s) of your resource, or add them if not found | `addOrUpdate(<instance>)` or `addOrUpdate(<array>)` | `{ type: '@@krf/ADD_OR_UPDATE>TODOS', payload: <instance> or <array> }` |
-| `remove` | remove instance(s) of your resource by its key | `remove([<key>])` | `{ type: '@@krf/REMOVE>TODOS', payload: [<key>] }` |
+| `remove` | remove instance(s) of your resource by its key or by an instance | `remove([<key>])` or `remove([<instance>])` | `{ type: '@@krf/REMOVE>TODOS', payload: [<key> or <instance>] }` |
 | `reset` | reset the reducer (wipe all data) | `reset()` | `{ type: '@@krf/RESET>TODOS' }` |
 
 ### selectors

--- a/src/types/keyValue/__snapshots__/keyValue.middleware.spec.js.snap
+++ b/src/types/keyValue/__snapshots__/keyValue.middleware.spec.js.snap
@@ -897,12 +897,123 @@ Object {
 }
 `;
 
+exports[`middlewares/keyValue should remove element by its reference [elm1] 1`] = `
+Object {
+  "action": Object {
+    "payload": Object {
+      "code": "elm1",
+      "infos": "elm1",
+      "some": "other",
+      "subinfos": Object {
+        "info": "elm1",
+      },
+    },
+    "type": "@@krf/REMOVE>TESTPREFIX>TESTNAME",
+  },
+  "state": Object {
+    "array": Array [
+      Object {
+        "code": "elm2",
+        "infos": "elm2",
+        "some": "other",
+        "subinfos": Object {
+          "info": "elm2",
+        },
+      },
+      Object {
+        "code": "elm3",
+        "infos": "elm3",
+        "some": "other",
+        "subinfos": Object {
+          "info": "elm3",
+        },
+      },
+    ],
+    "data": Object {
+      "elm2": Object {
+        "code": "elm2",
+        "infos": "elm2",
+        "some": "other",
+        "subinfos": Object {
+          "info": "elm2",
+        },
+      },
+      "elm3": Object {
+        "code": "elm3",
+        "infos": "elm3",
+        "some": "other",
+        "subinfos": Object {
+          "info": "elm3",
+        },
+      },
+    },
+    "initialized": true,
+    "keys": Array [
+      "elm2",
+      "elm3",
+    ],
+  },
+}
+`;
+
 exports[`middlewares/keyValue should remove elements [elm1, elm2] 1`] = `
 Object {
   "action": Object {
     "payload": Array [
       "elm1",
       "elm2",
+    ],
+    "type": "@@krf/REMOVE>TESTPREFIX>TESTNAME",
+  },
+  "state": Object {
+    "array": Array [
+      Object {
+        "code": "elm3",
+        "infos": "elm3",
+        "some": "other",
+        "subinfos": Object {
+          "info": "elm3",
+        },
+      },
+    ],
+    "data": Object {
+      "elm3": Object {
+        "code": "elm3",
+        "infos": "elm3",
+        "some": "other",
+        "subinfos": Object {
+          "info": "elm3",
+        },
+      },
+    },
+    "initialized": true,
+    "keys": Array [
+      "elm3",
+    ],
+  },
+}
+`;
+
+exports[`middlewares/keyValue should remove elements by their references [elm1, elm2] 1`] = `
+Object {
+  "action": Object {
+    "payload": Array [
+      Object {
+        "code": "elm1",
+        "infos": "elm1",
+        "some": "other",
+        "subinfos": Object {
+          "info": "elm1",
+        },
+      },
+      Object {
+        "code": "elm2",
+        "infos": "elm2",
+        "some": "other",
+        "subinfos": Object {
+          "info": "elm2",
+        },
+      },
     ],
     "type": "@@krf/REMOVE>TESTPREFIX>TESTNAME",
   },

--- a/src/types/keyValue/keyValue.middleware.js
+++ b/src/types/keyValue/keyValue.middleware.js
@@ -47,10 +47,13 @@ const addOrUpdate = shouldAdd => (key, state, payload) => {
 }
 
 const remove = (key, state, payload) => {
-  const keysToRemove = getAsArray(payload)
+  const payloadAsArray = getAsArray(payload)
   const data = { ...state.data }
 
-  keysToRemove.forEach((k) => { delete data[k] })
+  payloadAsArray.forEach((entity) => {
+    const keyToRemove = typeof entity === 'object' ? entity[key] : entity
+    delete data[keyToRemove]
+  })
 
   return mapDataToState(state)(data)
 }

--- a/src/types/keyValue/keyValue.middleware.spec.js
+++ b/src/types/keyValue/keyValue.middleware.spec.js
@@ -78,6 +78,16 @@ describe('middlewares/keyValue', () => {
     action: remove(prefix)(name)(['elm1', 'elm2']),
   })).toMatchSnapshot())
 
+  it('should remove element by its reference [elm1]', () => expect(testPrefix({
+    state,
+    action: remove(prefix)(name)(state.data.elm1),
+  })).toMatchSnapshot())
+
+  it('should remove elements by their references [elm1, elm2]', () => expect(testPrefix({
+    state,
+    action: remove(prefix)(name)([state.data.elm1, state.data.elm2]),
+  })).toMatchSnapshot())
+
   it('should reset state', () => expect(testPrefix({
     state,
     action: reset(prefix)(name)(),


### PR DESCRIPTION
fixes #118 

@EmrysMyrddin This is not really "by reference", because we are looking for the key if the type is `object` but I guess it is ok like that ? WDYT ?

